### PR TITLE
feat: add useUserMedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Each composition function is designed to degrade gracefully so you can safely us
 - [Preferred Color Scheme](https://logaretm.github.io/vue-use-web/guide/preferred-color-scheme.md).
 - [Preferred Languages](https://logaretm.github.io/vue-use-web/guide/preferred-languages.md).
 - [Script](https://logaretm.github.io/vue-use-web/guide/script.md).
+- [User Media](https://logaretm.github.io/vue-use-web/user-media.md)
 - [Window Scroll Position](https://logaretm.github.io/vue-use-web/guide/scroll-position.md).
 - [Window Size](https://logaretm.github.io/vue-use-web/guide/window-size.md).
 - Bluetooth (WIP).

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -70,6 +70,7 @@ module.exports = {
         'preferred-languages',
         'script',
         'scroll-position',
+        'user-media',
         'window-size'
       ],
       '/examples/': []

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ npm install @vue/composition-api vue-use-web
 - [Preferred Color Scheme](./guide/preferred-color-scheme.md).
 - [Preferred Languages](./guide/preferred-languages.md).
 - [Script](./guide/script.md).
+- [User Media](./guide/user-media.md)
 - [Window Scroll Position](./guide/scroll-position.md).
 - [Window Size](./guide/window-size.md).
 - Bluetooth <Badge text="WIP" type="warn" />.

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -35,6 +35,7 @@ These are the currently implemented Web APIs and the planned ones.
 - [Preferred Color Scheme](./preferred-color-scheme.md).
 - [Preferred Languages](./preferred-languages.md).
 - [Script](./script.md).
+- [User Media](./user-media.md)
 - [Window Scroll Position](./scroll-position.md).
 - [Window Size](./window-size.md).
 - Bluetooth <Badge text="WIP" type="warn" />.

--- a/docs/guide/user-media.md
+++ b/docs/guide/user-media.md
@@ -1,0 +1,71 @@
+# UserMedia
+
+> The [MediaDevices.getUserMedia()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia) method prompts the user for permission to use a media input which produces a MediaStream with tracks containing the requested types of media. That stream can include, for example, a video track (produced by either a hardware or virtual video source such as a camera, video recording device, screen sharing service, and so forth), an audio track (similarly, produced by a physical or virtual audio source like a microphone, A/D converter, or the like), and possibly other track types.
+
+## State
+
+The `useUserMedia` function exposes the following reactive state:
+
+```js
+import { useUserMedia } from 'vue-use-web';
+
+const { promise, error } = useUserMedia({ audio: true, video: true });
+```
+
+| State   | Type                          | Description                                                |
+| ------- | ----------------------------- | ---------------------------------------------------------- |
+| promise | `Promise<MediaStream> | null` | A promise resolving with the media stream object.          |
+| error   | `Error | null`                | An error instance, for example if constraints are invalid. |
+
+## Config
+
+`useUserMedia` function accepts an object that has the type of [`MediaStreamConstraints`](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamConstraints).
+
+```js
+import { useUserMedia } from 'vue-use-web';
+
+const constraints = { audio: true, video: false };
+
+const { promise } = useUserMedia(constraints);
+```
+
+| Config      | Type                                                                                                                               | Description |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| constraints | [`MediaStreamConstraints`](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamConstraints)` | A media constraints object. |
+
+## Example
+
+This example pipes the stream from the promise to a audio element to play the live audio stream.
+
+```vue
+<template>
+  <div>
+    <audio controls ref="vod"></audio>
+  </div>
+</template>
+
+<script>
+import { ref } from '@vue/composition-api';
+import { useUserMedia } from 'vue-use-web';
+
+export default {
+  setup() {
+    const vod = ref(null);
+    console.log(
+      useUserMedia({
+        audio: true,
+        video: false
+      }).promise.value.then(stream => {
+        vod.value.srcObject = stream;
+      })
+    );
+
+    return {
+      vod
+    };
+  }
+};
+</script>
+```
+
+TODO: Live Demo

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint . '**/*.{js,jsx,ts,tsx}' --fix",
     "ts:defs": "./scripts/defs.sh",
     "build": "node ./scripts/build && npm run ts:defs",
-    "prepublish": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "author": "Abdelrahman Awad <logaretm1@gmail.com>",
   "license": "MIT",

--- a/src/UserMedia.ts
+++ b/src/UserMedia.ts
@@ -1,0 +1,32 @@
+import { onMounted, ref } from '@vue/composition-api';
+
+export function useUserMedia(constraints: MediaStreamConstraints) {
+  const error = ref('');
+
+  const promise: Promise<MediaStream> = new Promise((resolve, reject) => {
+    onMounted(() => {
+      navigator.mediaDevices
+        .getUserMedia(constraints)
+        .then(resolve)
+        .catch(err => {
+          if (err.name === 'ConstraintNotSatisfiedError') {
+            error.value = 'constrains not satisfied';
+            return;
+          }
+
+          if (err.name === 'PermissionDeniedError') {
+            error.value = 'user denied permission';
+            return;
+          }
+
+          error.value = `${err.name}: ${err.message}`;
+          reject(err);
+        });
+    });
+  });
+
+  return {
+    error,
+    toPromise: () => promise
+  };
+}

--- a/src/UserMedia.ts
+++ b/src/UserMedia.ts
@@ -1,32 +1,25 @@
-import { onMounted, ref } from '@vue/composition-api';
+import { onMounted, reactive, toRefs } from '@vue/composition-api';
 
 export function useUserMedia(constraints: MediaStreamConstraints) {
-  const error = ref('');
+  const dataDefs: { error: Error | null; promise: Promise<MediaStream> | null } = {
+    error: null,
+    promise: null
+  };
 
-  const promise: Promise<MediaStream> = new Promise((resolve, reject) => {
+  const state = reactive(dataDefs);
+  state.promise = new Promise((resolve, reject) => {
     onMounted(() => {
       navigator.mediaDevices
         .getUserMedia(constraints)
         .then(resolve)
         .catch(err => {
-          if (err.name === 'ConstraintNotSatisfiedError') {
-            error.value = 'constrains not satisfied';
-            return;
-          }
-
-          if (err.name === 'PermissionDeniedError') {
-            error.value = 'user denied permission';
-            return;
-          }
-
-          error.value = `${err.name}: ${err.message}`;
+          state.error = err;
           reject(err);
         });
     });
   });
 
   return {
-    error,
-    toPromise: () => promise
+    ...toRefs(state)
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,5 +13,6 @@ export * from './Network';
 export * from './PreferredColorScheme';
 export * from './PreferredLanguages';
 export * from './Script';
+export * from './UserMedia';
 export * from './WindowScrollPosition';
 export * from './WindowSize';


### PR DESCRIPTION
This implements a `useUserMedia` hook to mirror the [Media Devices API](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices)


```vue
<template>
  <div>
    <audio controls ref="audio"></audio>
  </div>
</template>

<script>
import { ref } from "@vue/composition-api";
import { useUserMedia } from "vue-use-web";

export default {
  setup() {
    const audio = ref(null);
    useUserMedia({
      audio: true,
      video: false
    })
      .promise.value.then(strem => {
        audio.value.srcObject = strem;
      });

    return {
      audio
    };
  }
};
</script>
```

I'm not yet sold how is this useful as it just wraps the original API calls.